### PR TITLE
Fixed compile error resulting from PR#29

### DIFF
--- a/book_browsing_sorting/views.py
+++ b/book_browsing_sorting/views.py
@@ -24,7 +24,7 @@ def top_ten_books_sold():
     #    Sort by unitsSold decreasing
     booksQuery = Books.query.all()
     books: list = booksSchema.dump(booksQuery)
-    sortedBooks = sorted(books, key=sortByUnitsSold, reverse=True)\
+    sortedBooks = sorted(books, key = sortByUnitsSold, reverse = True)
 
     # check size of sortedBooks.  If greater than 10, return only top ten, else return sorted books
     if len(sortedBooks) > 10:

--- a/models/db_Shopping_Cart_Items.py
+++ b/models/db_Shopping_Cart_Items.py
@@ -1,12 +1,13 @@
 from core import db, marshmallow
 from datetime import datetime
 
+
 # Authors table Model
 class ShoppingCartItems(db.Model):
     __tablename__ = 'ShoppingCartItems'
-    idShoppingCartItems = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    idShoppingCart = db.column(db.Integer,db.ForeignKey('ShoppingCarts.idShoppingCarts'),nullable = False)
-    isbn = db.Column(db.String(55), nullable=False)
+    idShoppingCartItems = db.Column(db.Integer, primary_key = True, autoincrement = True)
+    idShoppingCart = db.Column(db.Integer, db.ForeignKey('ShoppingCarts.idShoppingCarts'), nullable = False)
+    isbn = db.Column(db.String(55), nullable = False)
 
 
 def __init__(self, idShoopingCartItems, idShoppingCart, isbn):
@@ -18,8 +19,8 @@ def __init__(self, idShoopingCartItems, idShoppingCart, isbn):
 # JSON Schema
 class ShoppingCartItemsSchema(marshmallow.Schema):
     class Meta:
-        fields = ('idShoppingCartItems', 'idShoppingCart','isbn')
+        fields = ('idShoppingCartItems', 'idShoppingCart', 'isbn')
 
 
 ShoppingCartItems_schema = ShoppingCartItemsSchema()
-ShoppingCartItems_many_schema = ShoppingCartItemsSchema(many=True)
+ShoppingCartItems_many_schema = ShoppingCartItemsSchema(many = True)


### PR DESCRIPTION
There was a compile error caused by a typo in line 8 of db_Shopping_Cart_Items.py.  db.column(...) instead of db.Column(...).  Fixed the typo and validated project is compiling again.